### PR TITLE
Changing from docker to podman

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install molecule 'molecule-plugins[docker]' yamllint ansible-lint
+        run: pip3 install yamllint ansible-lint
 
       - name: Lint code.
         run: |
@@ -52,7 +52,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install ansible molecule 'molecule-plugins[docker]' docker
+        run: pip3 install ansible molecule 'molecule-plugins[podman]' podman
 
       - name: Run Molecule tests.
         run: molecule test -s ${{ matrix.scenario }}

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -3,7 +3,7 @@ role_name_check: 1
 dependency:
   name: galaxy
 driver:
-  name: docker
+  name: podman
 platforms:
   - name: ${MOLECULE_DISTRO:-rockylinux9}
     image: "geerlingguy/docker-${MOLECULE_DISTRO:-rockylinux9}-ansible:latest"

--- a/molecule/local/molecule.yml
+++ b/molecule/local/molecule.yml
@@ -3,7 +3,7 @@ role_name_check: 1
 dependency:
   name: galaxy
 driver:
-  name: docker
+  name: podman
 platforms:
   - name: rockylinux8
     image: geerlingguy/docker-rockylinux8-ansible:latest


### PR DESCRIPTION
With this commit I am changing the default molecule environment from docker to podman. This was originally proposed by mrolli in favor of FOSS tool.

After a breaking change in a docker dependency after May 1, 2023 this change is even more logical in order to get working Github Actions again.

# Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist
- [x] I have tested this code
- [ ] I have updated the README.md (if available and necessary)

