### PR TITLE
Ant - interactive role creation from template

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#using-a-matrix-strategy
     strategy:
       matrix:
-        distro: [rockylinux8, rockylinux9, ubuntu2004, ubuntu2204]
+        distro: [<<range .Platforms>><< . >>, <<end>>]
         scenario: [default]
         include:
           - playbook: converge.yml

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Including an example of how to use your role (for instance, with variables passe
 
     - hosts: servers
       roles:
-         - { role: ubelix.template, x: 42 }
+         - { role: << .Namespace >>.<< .Name >>, x: 42 }
 
 License
 -------
 
-TBD
+<< .License >>
 

--- a/README.md
+++ b/README.md
@@ -36,13 +36,12 @@ Including an example of how to use your role (for instance, with variables passe
 ## Compatibility
 
 This role has been written for and tested on and is therefore compatible with:
-
-<< range .Platforms ->>
-<< if eq . "rockylinux8" >> * Rocky-8<<end >>
-<< if eq . "rockylinux9" >> * Rocky-9<<end >>
+<< range .Platforms >>
+<< if eq . "rockylinux8" >> * Rocky-8<<end>>
+<< if eq . "rockylinux9" >> * Rocky-9<<end>>
 << if eq . "ubuntu2004" >> * Ubuntu 20.04<<end>>
 << if eq . "ubuntu2204" >> * Ubuntu 22.04<<end>>
-<<- end >>
+<< end >>
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,26 +1,31 @@
-template
-=========
+# template
 
-This is an ansible role template for hpc-unibe-ch.
-A brief description of the role and its capabilities should go here.
+An Ansible role that manages template. Currently the role has the following
+features:
 
-Style Conventions 
------------------
+* template feature 1
+* template feature 2
+* template feature 3
 
-TDB
+## Requirements
 
-* All variabled should start with the role name (e.g. `template_`)
-* OS-specific variables should be set in the `vars` directory and start with `__template_`
+No prerequisites necessary at the moment.
 
+## Role Variables
 
-Role Variables
---------------
+Available variables are listed below, along with default values (see also `defaults/main.yml`):
 
-A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+> **Note:**
+> * All variabled should start with the role name (e.g. `template_`)
+> * OS-specific variables should be set in the `vars` directory and start with `__template_`
 
+### template_variable
 
-Example Playbook
-----------------
+    template_variable: "42"
+
+Specifies the number that template uses
+
+## Example Playbook
 
 Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
 
@@ -28,8 +33,21 @@ Including an example of how to use your role (for instance, with variables passe
       roles:
          - { role: << .Namespace >>.<< .Name >>, x: 42 }
 
-License
--------
+## Compatibility
+
+This role has been written for and tested on and is therefore compatible with:
+
+<< range .Platforms ->>
+<< if eq . "rockylinux8" >> * Rocky-8<<end >>
+<< if eq . "rockylinux9" >> * Rocky-9<<end >>
+<< if eq . "ubuntu2004" >> * Ubuntu 20.04<<end>>
+<< if eq . "ubuntu2204" >> * Ubuntu 22.04<<end>>
+<<- end >>
+
+## License
 
 << .License >>
 
+## Author Information
+
+The role was created in 2023 by the << .Author >> at << .Company >>

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ No prerequisites necessary at the moment.
 Available variables are listed below, along with default values (see also `defaults/main.yml`):
 
 > **Note:**
+
 > * All variabled should start with the role name (e.g. `template_`)
 > * OS-specific variables should be set in the `vars` directory and start with `__template_`
 
@@ -27,11 +28,14 @@ Specifies the number that template uses
 
 ## Example Playbook
 
-Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+Including an example of how to use your role (for instance, with variables passed
+in as parameters) is always nice for users too:
 
     - hosts: servers
       roles:
-         - { role: << .Namespace >>.<< .Name >>, x: 42 }
+         - role: << .Namespace >>.<< .Name >>
+           vars:
+             << .Name >>_x: 42
 
 ## Compatibility
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,17 +12,17 @@ galaxy_info:
   min_ansible_version: '2.1'
 
   platforms:
-    << if .Versions.el >>
+    <<if not .VersionsEL>>
     - name: EL
       versions:
-        - '8'
-        - '9'
-    << end >>
-    << if .Versions.ubuntu >> 
+    <<range .VersionsEL>>
+        - '<< . >>'
+    <<end>>
+    <<if not .VersionsUbuntu>>
     - name: Ubuntu
       versions:
-        - focal
-        - jammy
+    <<range .VersionsUbuntu>>
+        - '<< . >>'
     << end >>
 
   galaxy_tags: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,13 +12,13 @@ galaxy_info:
   min_ansible_version: '2.1'
 
   platforms:
-    << if .versions.el }}
+    << if .versions.el >>
     - name: EL
       versions:
         - '8'
         - '9'
     << end >>
-    << if .versions.ubuntu }}
+    << if .versions.ubuntu >> 
     - name: Ubuntu
       versions:
         - focal

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,24 +1,24 @@
 ---
 galaxy_info:
-  author: << .author >>
-  description: << .description >>
-  company: << .company >>
+  author: << .Author >>
+  description: << .Description >>
+  company: << .Company >>
 
-  role_name: << .name >>
-  namespace: << .namespace >>
+  role_name: << .Name >>
+  namespace: << .Namespace >>
 
-  license: << .license >>
+  license: << .License >>
 
   min_ansible_version: '2.1'
 
   platforms:
-    << if .versions.el >>
+    << if .Versions.el >>
     - name: EL
       versions:
         - '8'
         - '9'
     << end >>
-    << if .versions.ubuntu >> 
+    << if .Versions.ubuntu >> 
     - name: Ubuntu
       versions:
         - focal

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -18,12 +18,14 @@ galaxy_info:
     <<range .VersionsEL>>
         - '<< . >>'
     <<end>>
+    <<end>>
     <<if not .VersionsUbuntu>>
     - name: Ubuntu
       versions:
     <<range .VersionsUbuntu>>
         - '<< . >>'
-    << end >>
+    <<end>>
+    <<end>>
 
   galaxy_tags: []
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,20 +12,17 @@ galaxy_info:
   min_ansible_version: '2.1'
 
   platforms:
-    <<if not .VersionsEL>>
+    <<- if .VersionsEL>>
     - name: EL
       versions:
-    <<range .VersionsEL>>
-        - '<< . >>'
-    <<end>>
-    <<end>>
-    <<if not .VersionsUbuntu>>
+        <<range .VersionsEL>>- '<< . >>' <<end>>
+    << end ->>
+    <<- if .VersionsUbuntu ->>
     - name: Ubuntu
       versions:
-    <<range .VersionsUbuntu>>
-        - '<< . >>'
-    <<end>>
-    <<end>>
+      <<range .VersionsUbuntu>>- '<< . >>'
+      <<end>>
+    <<end ->>
 
   galaxy_tags: []
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,18 +11,25 @@ galaxy_info:
 
   min_ansible_version: '2.1'
 
+  <<- $hasRocky := 0 >> <<- range .Platforms>><<if or (eq . "rockylinux8") (eq . "rockylinux9")>><<$hasRocky = 1>><<end>><<end >>
+  << $hasUbuntu := 0 >> << range .Platforms>><<if or (eq . "ubuntu2004") (eq . "ubuntu2204")>><<$hasUbuntu = 1>><<end>><<end >>
   platforms:
-    <<- if .VersionsEL>>
+    << if $hasRocky ->>
     - name: EL
       versions:
-        <<range .VersionsEL>>- '<< . >>' <<end>>
     << end ->>
-    <<- if .VersionsUbuntu ->>
+    << range .Platforms ->>
+    << if eq . "rockylinux8" >>    - '8'<<end >>
+    << if eq . "rockylinux9" >>    - '9'<<end >>
+    <<- end >>
+    << if $hasUbuntu ->>
     - name: Ubuntu
       versions:
-      <<range .VersionsUbuntu>>- '<< . >>'
-      <<end>>
-    <<end ->>
+    << end ->>
+    <<- range .Platforms ->>
+    << if eq . "ubuntu2004" >>    - 'focal'<<end>>
+    << if eq . "ubuntu2204" >>    - 'jammy'<<end>>
+    <<- end >>
 
   galaxy_tags: []
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,25 +1,29 @@
 ---
 galaxy_info:
-  author: <Author name>
-  description: <Short description of the role>
-  company: hpc-unibe-ch
+  author: << .author >>
+  description: << .description >>
+  company: << .company >>
 
-  role_name: template
-  namespace: ubelix
+  role_name: << .name >>
+  namespace: << .namespace >>
 
-  license: GPL-2.0-or-later
+  license: << .license >>
 
   min_ansible_version: '2.1'
 
   platforms:
+    << if .versions.el }}
     - name: EL
       versions:
         - '8'
         - '9'
+    << end >>
+    << if .versions.ubuntu }}
     - name: Ubuntu
       versions:
         - focal
         - jammy
+    << end >>
 
   galaxy_tags: []
 

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -5,4 +5,4 @@
   tasks:
     - name: "Include ansible-role-template"
       ansible.builtin.include_role:
-        name: "ubelix.template"
+        name: "<< .Namespace >>.template"

--- a/molecule/local/molecule.yml
+++ b/molecule/local/molecule.yml
@@ -5,38 +5,16 @@ dependency:
 driver:
   name: podman
 platforms:
-  - name: rockylinux8
-    image: geerlingguy/docker-rockylinux8-ansible:latest
+  <<range .Platforms>>
+  - name: << . >> 
+    image: geerlingguy/docker-<< . >>-ansible:latest
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
     privileged: true
     pre_build_image: true
-  - name: rockylinux9
-    image: geerlingguy/docker-rockylinux9-ansible:latest
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    cgroupns_mode: host
-    privileged: true
-    pre_build_image: true
-  - name: ubuntu2004
-    image: geerlingguy/docker-ubuntu2004-ansible:latest
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    cgroupns_mode: host
-    privileged: true
-    pre_build_image: true
-  - name: ubuntu2204
-    image: geerlingguy/docker-ubuntu2204-ansible:latest
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    cgroupns_mode: host
-    privileged: true
-    pre_build_image: true
+  << end >>
 provisioner:
   name: ansible
   playbooks:

--- a/vars/Rocky-8.yml
+++ b/vars/Rocky-8.yml
@@ -1,0 +1,3 @@
+---
+
+__template_some_variable: True


### PR DESCRIPTION
This PR enables interactive role creation from this template through [ant](https://github.com/grvlbit/ant).
Ant is written in go and uses it's own templating engine to replace text in files. Everything in `<<` and `>>` is modified with ant. 

The idea of interactive role creation is to automatically insert info into `meta/main.yml` and set license and environments as requested. This way it's easy to create a role from this template that will only work with ubuntu. After the new role is created from template, a `molecule test -s local` should immeadeately work on the requested OSes. 

# Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist
- [x] I have tested this code
- [ ] I have updated the README.md (if available and necessary)

# Other comments

